### PR TITLE
Extend terralib.saveobj API to allow for enabling/disabling LLVM's op…

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2870,11 +2870,12 @@ static int terra_saveobjimpl(lua_State * L) {
     
     const char * filename = lua_tostring(L, 1); //NULL means write to memory
     std::string filekind = lua_tostring(L,2);
-    int argument_index = 4;
-    
+    bool optimize = lua_toboolean(L,4);
+    int argument_index = 5;
     lua_getfield(L,3,"llvm_cu");
     TerraCompilationUnit * CU = (TerraCompilationUnit*) terra_tocdatapointer(L,-1); assert(CU);
-    llvmutil_optimizemodule(CU->M,CU->TT->tm);
+    if (optimize)
+        llvmutil_optimizemodule(CU->M,CU->TT->tm);
     //TODO: interialize the non-exported functions?
     std::vector<const char *> args;
     int nargs = lua_objlen(L,argument_index);

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -3976,11 +3976,16 @@ function T.quote:__tostring() return self:prettystring(false) end
 
 local allowedfilekinds = { object = true, executable = true, bitcode = true, llvmir = true, sharedlibrary = true, asm = true }
 local mustbefile = { sharedlibrary = true, executable = true }
-function compilationunit:saveobj(filename,filekind,arguments)
+function compilationunit:saveobj(filename,filekind,arguments,optimize)
     if filekind ~= nil and type(filekind) ~= "string" then
         --filekind is missing, shift arguments to the right
-        filekind,arguments = nil,filekind
+        filekind,arguments,optimize = nil,filekind,arguments
     end
+    -- default behavior for optimize is true
+    if (optimize == nil) then
+        optimize = true
+    end 
+       
     if filekind == nil and filename ~= nil then
         --infer filekind from string
         if filename:match("%.o$") then
@@ -4003,19 +4008,19 @@ function compilationunit:saveobj(filename,filekind,arguments)
     if filename == nil and mustbefile[filekind] then
         error(filekind .. " must be written to a file")
     end
-    return terra.saveobjimpl(filename,filekind,self,arguments or {})
+    return terra.saveobjimpl(filename,filekind,self,optimize,arguments or {})
 end
 
-function terra.saveobj(filename,filekind,env,arguments,target)
+function terra.saveobj(filename,filekind,env,arguments,target,optimize)
     if type(filekind) ~= "string" then
-        filekind,env,arguments,target = nil,filekind,env,arguments
+        filekind,env,arguments,target,optimize = nil,filekind,env,arguments,target
     end
     local cu = terra.newcompilationunit(target or terra.nativetarget,false)
     for k,v in pairs(env) do
         if not T.globalvalue:isclassof(v) then error("expected terra global or function but found "..terra.type(v)) end
         cu:addvalue(k,v)
     end
-    local r = cu:saveobj(filename,filekind,arguments)
+    local r = cu:saveobj(filename,filekind,arguments,optimize)
     cu:free()
     return r
 end


### PR DESCRIPTION
…timization passes. The new API is as follows

terralib.saveobj(filename, [,filetype], functiontable[,arguments,target], [optimize])
optimize is a boolean value. The default is set to true i.e. enable the optimization passes.